### PR TITLE
no module errors

### DIFF
--- a/netconfig/aiproute.py
+++ b/netconfig/aiproute.py
@@ -4,7 +4,7 @@
 import asyncio
 import netaddr
 import time
-from pyroute2 import IPRoute
+from pyroute2 import IPRoute  # noqa pylint: disable=no-name-in-module, import-error
 try:
     from pyroute2 import IPLinkRequest
 except ImportError:

--- a/netconfig/iwroute.py
+++ b/netconfig/iwroute.py
@@ -4,13 +4,15 @@
 import asyncio
 from functools import partial
 
-from pr2modules.netlink.nl80211 import nl80211cmd  # noqa pylint: disable=no-name-in-module, import-error
-from pr2modules.netlink.nl80211 import NL80211_NAMES  # noqa pylint: disable=no-name-in-module, import-error
-from pr2modules.netlink import NLM_F_ACK  # noqa pylint: disable=no-name-in-module, import-error
-from pr2modules.netlink import NLM_F_REQUEST  # noqa pylint: disable=no-name-in-module, import-error
-from pyroute2.netlink.exceptions import NetlinkError  # noqa pylint: disable=no-name-in-module, import-error
+# noqa pylint: disable=no-name-in-module, import-error
+from pr2modules.netlink.nl80211 import nl80211cmd
+from pr2modules.netlink.nl80211 import NL80211_NAMES
+from pr2modules.netlink import NLM_F_ACK
+from pr2modules.netlink import NLM_F_REQUEST
+from pyroute2.netlink.exceptions import NetlinkError
 
-from pyroute2 import IW  # noqa pylint: disable=no-name-in-module, import-error
+from pyroute2 import IW
+# noqa pylint: enable=no-name-in-module, import-error
 
 
 class IWRoute:

--- a/netconfig/iwroute.py
+++ b/netconfig/iwroute.py
@@ -4,13 +4,13 @@
 import asyncio
 from functools import partial
 
-from pr2modules.netlink.nl80211 import nl80211cmd
-from pr2modules.netlink.nl80211 import NL80211_NAMES
-from pr2modules.netlink import NLM_F_ACK
-from pr2modules.netlink import NLM_F_REQUEST
-from pyroute2.netlink.exceptions import NetlinkError
+from pr2modules.netlink.nl80211 import nl80211cmd  # noqa pylint: disable=no-name-in-module, import-error
+from pr2modules.netlink.nl80211 import NL80211_NAMES  # noqa pylint: disable=no-name-in-module, import-error
+from pr2modules.netlink import NLM_F_ACK  # noqa pylint: disable=no-name-in-module, import-error
+from pr2modules.netlink import NLM_F_REQUEST  # noqa pylint: disable=no-name-in-module, import-error
+from pyroute2.netlink.exceptions import NetlinkError  # noqa pylint: disable=no-name-in-module, import-error
 
-from pyroute2 import IW
+from pyroute2 import IW  # noqa pylint: disable=no-name-in-module, import-error
 
 
 class IWRoute:

--- a/netconfig/netlink.py
+++ b/netconfig/netlink.py
@@ -52,10 +52,10 @@ async def monitor_state_change(queues):
         # use the _create_connection_transport method
         loop = asyncio.get_event_loop()
 
-        if isinstance(loop) == asyncio.unix_events._UnixSelectorEventLoop:
+        if isinstance(loop, asyncio.unix_events._UnixSelectorEventLoop):  # noqa pylint: disable=protected-access
             reader = asyncio.streams.StreamReader(loop=loop)
             protocol = asyncio.streams.StreamReaderProtocol(reader, loop=loop)
-            await loop._create_connection_transport(
+            await loop._create_connection_transport(  # noqa pylint: disable=protected-access
                     skt, lambda: protocol, None, ''
             )
 
@@ -66,7 +66,7 @@ async def monitor_state_change(queues):
             try:
                 if isinstance(
                         loop
-                ) == asyncio.unix_events._UnixSelectorEventLoop:
+                ) == asyncio.unix_events._UnixSelectorEventLoop:  # noqa pylint: disable=protected-access
                     data = await reader.read(READ_SIZE)
                 else:
                     data = await loop.sock_recv(skt, READ_SIZE)

--- a/netconfig/netlink.py
+++ b/netconfig/netlink.py
@@ -65,8 +65,8 @@ async def monitor_state_change(queues):
             # version based on loop._create_connection_transport
             try:
                 if isinstance(
-                        loop
-                ) == asyncio.unix_events._UnixSelectorEventLoop:  # noqa pylint: disable=protected-access
+                        loop, asyncio.unix_events._UnixSelectorEventLoop
+                ):  # noqa pylint: disable=protected-access
                     data = await reader.read(READ_SIZE)
                 else:
                     data = await loop.sock_recv(skt, READ_SIZE)

--- a/netconfig/netlink.py
+++ b/netconfig/netlink.py
@@ -52,7 +52,7 @@ async def monitor_state_change(queues):
         # use the _create_connection_transport method
         loop = asyncio.get_event_loop()
 
-        if type(loop) == asyncio.unix_events._UnixSelectorEventLoop:
+        if isinstance(loop) == asyncio.unix_events._UnixSelectorEventLoop:
             reader = asyncio.streams.StreamReader(loop=loop)
             protocol = asyncio.streams.StreamReaderProtocol(reader, loop=loop)
             await loop._create_connection_transport(
@@ -64,7 +64,9 @@ async def monitor_state_change(queues):
             # will this will only work with uvloop, refer to an older
             # version based on loop._create_connection_transport
             try:
-                if type(loop) == asyncio.unix_events._UnixSelectorEventLoop:
+                if isinstance(
+                        loop
+                ) == asyncio.unix_events._UnixSelectorEventLoop:
                     data = await reader.read(READ_SIZE)
                 else:
                     data = await loop.sock_recv(skt, READ_SIZE)

--- a/netconfig/wgroute.py
+++ b/netconfig/wgroute.py
@@ -4,7 +4,7 @@
 import asyncio
 
 from functools import partial
-from pyroute2 import WireGuard
+from pyroute2 import WireGuard  # noqa pylint: disable=no-name-in-module, import-error
 
 
 class WGRoute:


### PR DESCRIPTION
Issue: Part 1: https://github.com/ccxtechnologies/builder/issues/996

Solutions:
1. noqa pylint: disable=no-name-in-module, import-error **similar to ccxvpn** 
2. compare types, for exact checks use `is` / `is not`, 
for instance checks use `isinstance()`
3. use # noqa pylint: disable=protected-access
as it was done for https://github.com/ccxtechnologies/builder/issues/1067 and a few other places

testing :

![image](https://github.com/ccxtechnologies/netconfig/assets/101123177/64cc113d-a6e3-4b94-8658-05b12eb41b95)
