### PR TITLE
Checker netconfig pylint

### DIFF
--- a/netconfig/aiproute.py
+++ b/netconfig/aiproute.py
@@ -92,6 +92,7 @@ class AIPRoute():
         for r in response:
             mac = None
             address = None
+            confirmed_secs = None
             for name, value in r['attrs']:
                 if name == "NDA_DST":
                     address = value
@@ -99,7 +100,9 @@ class AIPRoute():
                     mac = value
                 elif name == "NDA_CACHEINFO":
                     confirmed_secs = value["ndm_confirmed"] / 100
-            if mac and address and (confirmed_secs < stale_timeout):
+            if mac and address and confirmed_secs and (
+                    confirmed_secs < stale_timeout
+            ):
                 cache[mac] = address
 
         return cache

--- a/netconfig/iface.py
+++ b/netconfig/iface.py
@@ -293,7 +293,7 @@ class Iface:
 
     def _ifreq(self):
         ifr = ifreq()
-        ifr.ifr_name = (ctypes.c_ubyte * IFNAMSIZ)(*bytearray(self._name))
+        ifr.ifr_name = (ctypes.c_ubyte * IFNAMSIZ)(*bytearray(self._name))  # noqa pylint: disable=attribute-defined-outside-init
         return ifr
 
     def get_index(self):

--- a/netconfig/mdio.py
+++ b/netconfig/mdio.py
@@ -169,7 +169,7 @@ class ifreq(ctypes.Structure):
 def mdio_read_reg(ifname, reg):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         ifr = ifreq()
-        ifr.ifr_name = (ctypes.c_ubyte * 16)(*bytearray(ifname.encode()))
+        ifr.ifr_name = (ctypes.c_ubyte * 16)(*bytearray(ifname.encode()))  # noqa pylint: disable=attribute-defined-outside-init
         fcntl.ioctl(sock, SIOCGMIIPHY, ifr)
         ifr.data.reg_num = reg
         fcntl.ioctl(sock, SIOCGMIIPHY, ifr)


### PR DESCRIPTION
Issue: https://github.com/ccxtechnologies/builder/issues/996 

Testing:
Pylint errors on netconfig resolved:
```zsh
❯ ctest "checker -a netconfig" quit                                                                                                                      
Using ctestrc file: /home/wardah/.ctestrc                                                                                                                
Application: netconfig.                                                                                                                                  
================================================================================                                                                         
= CCX Test Framework Version 1.2.32                                                                                                                      
================================================================================                                                                         
================================================================================                                                                         
= flake8 /home/wardah/builder/packages/netconfig                                                                                                         
================================================================================                                                                         
================================================================================                                                                         
= pylint /home/wardah/builder/packages/netconfig                                                                                                         
================================================================================                                                                         
                                                                                                                                                         
-------------------------------------------------------------------                                                                                      
Your code has been rated at 10.00/10 (previous run: 9.97/10, +0.03)                                                                                      
                                                                                                                                                         
================================================================================ 
```

**Still need to test aiproute since I made a change there**