### PR TITLE
replacing object type annotation with Any

### DIFF
--- a/netconfig/wgroute.py
+++ b/netconfig/wgroute.py
@@ -5,6 +5,7 @@ import asyncio
 
 from functools import partial
 from pyroute2 import WireGuard  # noqa pylint: disable=no-name-in-module, import-error
+from typing import Any
 
 
 class WGRoute:
@@ -47,7 +48,7 @@ class WGRoute:
                     self.executor, partial(self._info, ifname, ifindex)
             )
 
-    def get_attr(self, attr_name: str, attrs) -> object:
+    def get_attr(self, attr_name: str, attrs) -> Any:
         if attrs is None:
             return None
 

--- a/netconfig/wgroute.py
+++ b/netconfig/wgroute.py
@@ -47,7 +47,7 @@ class WGRoute:
                     self.executor, partial(self._info, ifname, ifindex)
             )
 
-    def get_attr(self, attr_name: str, attrs) -> Any:
+    def get_attr(self, attr_name: str, attrs) -> object:
         if attrs is None:
             return None
 

--- a/netconfig/wgroute.py
+++ b/netconfig/wgroute.py
@@ -5,7 +5,6 @@ import asyncio
 
 from functools import partial
 from pyroute2 import WireGuard  # noqa pylint: disable=no-name-in-module, import-error
-from typing import Any
 
 
 class WGRoute:

--- a/netconfig/wgroute.py
+++ b/netconfig/wgroute.py
@@ -75,8 +75,10 @@ class WGRoute:
 
         return _nested_values(attr_name, attrs)
 
-    def get_nested(self, attr_names: tuple, attrs: dict) -> object:
-        _attrs = attrs
+    def get_nested(
+            self, attr_names: tuple, attrs: list | dict | tuple
+    ) -> object:
+        _attrs: object = attrs
 
         for attr_name in attr_names:
             _attrs = self.get_attr(attr_name, _attrs)


### PR DESCRIPTION
Issue: https://github.com/ccxtechnologies/builder/issues/996

Fixing `mypy` error for `wgroute.py`:
`packages/netconfig/netconfig/wgroute.py:81: error: Incompatible types in assignment (expression has type "object", variable has type "dict[Any, Any]")  [assignment]`

Analysis:
- [here](https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2715178247) 
- [here](https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2715504971)

> * [ ]  `packages/netconfig/netconfig/wgroute.py:81: error: Incompatible types in assignment (expression has type "object", variable has type "dict[Any, Any]")  [assignment]`
>   Relevant line: https://github.com/ccxtechnologies/netconfig/blob/master/netconfig/wgroute.py#L81
> 
> _attrs = self.get_attr(attr_name, _attrs)
> context:
> 
> def get_nested(self, attr_names: tuple, attrs: dict) -> object:
>         _attrs = attrs
> 
>         for attr_name in attr_names:
>             _attrs = self.get_attr(attr_name, _attrs)
>         return _attrs
> `_attrs` is initialized here first `_attrs = attrs`, where `attrs` is a dict as seen in the function signature.
> 
> in the `get_attr` function, it's specified in the signature that the return value is an object: https://github.com/ccxtechnologies/netconfig/blob/fba11cea3f28c643b7ade7ccf8518b2c6a6a2674/netconfig/wgroute.py#L50 `def get_attr(self, attr_name: str, attrs) -> object`
> 
> `get_attr` can either return `None`, a [list](https://github.com/ccxtechnologies/netconfig/blob/master/netconfig/wgroute.py#L73), or `value` (what is the type of value?)
> 
> Root cause:
> - `_attrs` is annotated as a `dict`:
> `def get_nested(self, attr_names: tuple, attrs: dict`
> - the return type of `get_nested` is annotated as an `object`:
> `def get_attr(self, attr_name: str, attrs) -> object:`
> 
> This conflicts here:
> `_attrs = self.get_attr(attr_name, _attrs)`, an `object` type is being assigned to a `dict` type.
> 
> Type annotations [are not enforced by the Python runtime](https://docs.python.org/3/library/typing.html#the-any-type:~:text=The%20Python%20runtime%20does%20not%20enforce%20function%20and%20variable%20type%20annotations.), but they are used by checkers. 
> 
> What is the `object` type? Mentioned [here](https://docs.python.org/3/library/typing.html#the-type-of-class-objects:~:text=Contrast%20the%20behavior%20of%20Any%20with%20the%20behavior%20of%20object.%20Similar%20to%20Any%2C%20every%20type%20is%20a%20subtype%20of%20object.%20However%2C%20unlike%20Any%2C%20the%20reverse%20is%20not%20true%3A%20object%20is%20not%20a%20subtype%20of%20every%20other%20type.):
>Contrast the behavior of [Any](https://docs.python.org/3/library/typing.html#typing.Any) with the behavior of [object](https://docs.python.org/3/library/functions.html#object). Similar to [Any](https://docs.python.org/3/library/typing.html#typing.Any), every type is a subtype of [object](https://docs.python.org/3/library/functions.html#object). However, unlike [Any](https://docs.python.org/3/library/typing.html#typing.Any), the reverse is not true: [object](https://docs.python.org/3/library/functions.html#object) is not a subtype of every other type.
> 
>That means when the type of a value is [object](https://docs.python.org/3/library/functions.html#object), a type checker will reject almost all operations on it, and assigning it to a variable (or using it as a return value) of a more specialized type is a type error. For example: 

 _Originally posted by @wbilal-c in [#996](https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2715178247)_
 
 >Why is object being used here? def get_attr(self, attr_name: str, attrs) -> object instead of Any?
 
 > Note [here](https://docs.python.org/3/library/functions.html#object:~:text=Note%20object%20instances%20do%20not%20have%20__dict__%20attributes%2C%20so%20you%20can%E2%80%99t%20assign%20arbitrary%20attributes%20to%20an%20instance%20of%20object.): 
> 
>Use [object](https://docs.python.org/3/library/functions.html#object) to indicate that a value could be any type in a typesafe manner. Use [Any](https://docs.python.org/3/library/typing.html#typing.Any) to indicate that a value is dynamically typed.
> 
> So `object` should be used when we want to specify that that variable can hold any object, and has methods common to any object. Dictionaries have special attributes that are not assumed for all object types, and we're assigning the `object` return value to a `dictionary`. This would make more sense as `Any`. 
> 
> **Try**: Change to `Any`:
> ```zsh
> /home/wardah/builder/packages/netconfig/netconfig/wgroute.py:row50:col50:F821 undefined name 'Any'
>     def get_attr(self, attr_name: str, attrs) -> Any:
>                                                  ^
> ================================================================================
> = pylint /home/wardah/builder/packages/netconfig
> ================================================================================
> ************* Module netconfig.wgroute
> netconfig/wgroute.py:50:49: E0602: Undefined variable 'Any' (undefined-variable)
> 
> -------------------------------------------------------------------
> Your code has been rated at 9.97/10 (previous run: 10.00/10, -0.03)
> 
> ================================================================================
> = mypy /home/wardah/builder/packages/netconfig
> ================================================================================
> wgroute.py:50: error: Name "Any" is not defined  [name-defined]
> ```
> -> That didn't work, `Any` is not recognized, why?
> 
>  

 _Originally posted by @wbilal-c in [#996](https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2715504971)_
 
 
