### PR TITLE
returning None explicitly and type hinting optional

### DIFF
--- a/netconfig/iwroute.py
+++ b/netconfig/iwroute.py
@@ -13,6 +13,7 @@ from pyroute2.netlink.exceptions import NetlinkError
 
 from pyroute2 import IW
 # noqa pylint: enable=no-name-in-module, import-error
+from typing import Optional
 
 
 class IWRoute:
@@ -122,9 +123,8 @@ class IWRoute:
                     self.executor, partial(self._get_id, phy_id, device_name)
             )
 
-    async def add_device(
-            self, phy_id: int, device_name: str, device_type
-    ) -> int:
+    async def add_device(self, phy_id: int, device_name: str,
+                         device_type) -> Optional[int]:
         """
         device_type can be:
             1. adhoc
@@ -141,7 +141,7 @@ class IWRoute:
         """
 
         if not device_name or not device_type:
-            return
+            return None
 
         async with self.lock:
             return await self.loop.run_in_executor(

--- a/netconfig/iwroute.py
+++ b/netconfig/iwroute.py
@@ -13,7 +13,6 @@ from pyroute2.netlink.exceptions import NetlinkError
 
 from pyroute2 import IW
 # noqa pylint: enable=no-name-in-module, import-error
-from typing import Optional
 
 
 class IWRoute:
@@ -123,8 +122,9 @@ class IWRoute:
                     self.executor, partial(self._get_id, phy_id, device_name)
             )
 
-    async def add_device(self, phy_id: int, device_name: str,
-                         device_type) -> Optional[int]:
+    async def add_device(
+            self, phy_id: int, device_name: str, device_type
+    ) -> int | None:
         """
         device_type can be:
             1. adhoc


### PR DESCRIPTION
Issue: https://github.com/ccxtechnologies/builder/issues/996

Relevant comments with analysis:
- https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2721579144
- https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2721870062 

> -> trying the new type hint did not work, still expecting a return value
> 
> -> explicitly returning `None` along with the type hint mentioned above fixes the error. 
> 
> What is the difference between `return` and `return None`?
> 
> -> the return value for both is `NoneType`
> ```python
> ❯ python [test.py](http://test.py/)
> <class 'NoneType'>
> ❯ cat [test.py](http://test.py/)
> import typing
> 
> 
> def test_func(x: int, y: int) -> typing.Union[int, None]:
>     res = x + y
>     if (res > 10):
>         return res
>     else:
>         return None
> 
> 
> z = test_func(5, 2)
> print(type(z))
> ```
> 
> and see [here](https://github.com/ccxtechnologies/builder/issues/996#:~:text=eg%2C%20when%20returning,print(type(z)))
> 
> -> They are functionally the same but they have a difference in **semantic** meaning. No explicit return type implies that the return value is not useful if it is None or it's not meaningful. Specifying `return None` on the other hand means that we do want to do something with the return value, that `None` *means* something.
> 
> Looking at the [usage](https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2721870062) for `add_device`, it doesn't seem like the `None` case is being handled or acknowledged, which implies that it might not be important/meaningful?
> 
> ---------
> So a potential fix of adding the Optional type hint, and explicitly returning `None`:
> 
> ```diff
> --- a/netconfig/iwroute.py
> +++ b/netconfig/iwroute.py
> @@ -14,6 +14,8 @@ from pyroute2.netlink.exceptions import NetlinkError
>  from pyroute2 import IW
>  # noqa pylint: enable=no-name-in-module, import-error
>  
> +from typing import Optional
> +
>  
>  class IWRoute:
>  
> @@ -122,9 +124,8 @@ class IWRoute:
>                      self.executor, partial(self._get_id, phy_id, device_name)
>              )
>  
> -    async def add_device(
> -            self, phy_id: int, device_name: str, device_type
> -    ) -> int:
> +    async def add_device(self, phy_id: int, device_name: str,
> +                         device_type) -> Optional[int]:
>          """
>          device_type can be:
>              1. adhoc
> @@ -141,7 +142,7 @@ class IWRoute:
>          """
>  
>          if not device_name or not device_type:
> -            return
> +            return None
>  
>          async with self.lock:
>              return await self.loop.run_in_executor(
> ```
> 
> pros: 
> - fixes error
> - can also reduce confusion and increase consistency since the other return statement returns an expression as stated in the PEP8 [guidelines](https://peps.python.org/pep-0008/#programming-recommendations:~:text=Be%20consistent%20in,function%20(if%20reachable)%3A):
> Be consistent in return statements. Either all return statements in a function should return an expression, or none of them should. If any return statement returns an expression, any return statements where no value is returned should explicitly state this as return None, and an explicit return statement should be present at the end of the function (if reachable):
> 
> cons: we lose some semantic value by returning `None` explicitly, but this may be clarified by the type of `Optional[int]` instead. 
>  

 _Originally posted by @wbilal-c in [#996](https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2722517617)_