### PR TITLE
fixing get_nested type hints

### DIFF
--- a/netconfig/aiproute.py
+++ b/netconfig/aiproute.py
@@ -380,8 +380,10 @@ class AIPRoute():
 
         return _nested_values(attr_name, attrs)
 
-    def get_nested(self, attr_names: tuple, attrs: dict) -> object:
-        _attrs = attrs
+    def get_nested(
+            self, attr_names: tuple, attrs: list | dict | tuple
+    ) -> object:
+        _attrs: object = attrs
 
         for attr_name in attr_names:
             _attrs = self.get_attr(attr_name, _attrs)


### PR DESCRIPTION
**Fixing this ctest error**:
`aiproute.py:387: error: Incompatible types in assignment (expression has type "object", variable has type "dict[Any, Any]")  [assignment]`

**From issue**: https://github.com/ccxtechnologies/builder/issues/4942


**Analysis**:

**problem** : 
- `attrs` in `get_nested` is typed as a `dict`, then assigned to `_attrs`, `_attrs` then inherits the `dict` type, then `_attrs` is assigned an `object` by calling `get_attr`, **`object` is incompatible with `dict` because `object` is not an instance of `dict`**
- the parameter to `get_nested`, `attrs`, should be an iterator, should not have only `dict` as its type hint, it can be specifically `dict`, `list`, or `tuple` (see [here](https://github.com/ccxtechnologies/builder/issues/996#issuecomment-2758703856))

**conclusion**: 
-> It makes the most sense to differentiate the type of the return type of `get_nested` and the parameter `attrs`

**fix**: 
- `_attrs` the return value is now typed as `object`, being compatible with `object`
- `attrs` the parameter can remain a `dict` and be assigned to `_attrs` because `dict` is an instance of `object`
  - further, added more specific type annotations for `attrs` because it can actually be more than a `dict`

**Note**:
- [`aiproute`](https://github.com/ccxtechnologies/netconfig/blob/85049a84186bed08690cee9f4fb199cd3d72c407/netconfig/aiproute.py#L356-L388) has the same `get_nested` and `get_attr` functions as [`wgroute`](https://github.com/ccxtechnologies/netconfig/blob/fba11cea3f28c643b7ade7ccf8518b2c6a6a2674/netconfig/wgroute.py#L50-L82) `get_nested` and `get_attr`
- we had the same ctest error for `wgroute`, this approach follows the same solution that was merged here:
  - see analysis: https://github.com/ccxtechnologies/netconfig/pull/8#issuecomment-2758878129
