### PR TITLE
Adding None type hint and returning None explicitly

### DIFF
--- a/netconfig/aiproute.py
+++ b/netconfig/aiproute.py
@@ -436,9 +436,9 @@ class AIPRoute():
 
     async def add_device(
             self, device_name: str, device_type: str, **kwargs
-    ) -> int:
+    ) -> int | None:
         if not device_name or not device_type:
-            return
+            return None
 
         async with self.lock:
             return await self.loop.run_in_executor(


### PR DESCRIPTION
**Fixing this ctest error**: 
`aiproute.py:439: error: Return value expected  [return-value]`

**From issue**: https://github.com/ccxtechnologies/builder/issues/4942

#### Analysis:

**Problem**: 
- `add_device` function type hint is wrong, we're implicitly returning `None` as well as an `int`, but the return type hint is only `int`
-  We're not explicitly returning `None`, but in the second return in `add_device`, we're explicitly returning an expression. PEP 8 standards recommend consistent return statement usage, so if we're returning an expression somewhere in a function, then we should use explicit returns everywhere in that function:
    - From [guidelines](https://peps.python.org/pep-0008/#programming-recommendations:~:text=Be%20consistent%20in,function%20(if%20reachable)%3A):
      >Be consistent in return statements. Either all return statements in a function should return an expression, or none of them should. If any return statement returns an expression, any return statements where no value is returned should explicitly state this as return None, and an explicit return statement should be present at the end of the function (if reachable):

**Conclusion**: The function return type hint should reflect both return types, `None` and `int`. To stay consistent with return types as per PEP 8 guidelines, we should explicitly return `None` since we're returning an expression in a different return statement in `add_device`

**Fix**: 
- change type hint to `int | None`
- explicitly return `None` instead of just `return`

**Note**:
- This is the same ctest error and root cause that we had for `iwroute.py`: `iwroute.py:144: error: Return value expected  [return-value]`
- This approach follows the same solution that was merged here:
  - see analysis: https://github.com/ccxtechnologies/netconfig/pull/9#issuecomment-2733626280



