### PR TITLE
returning None instead of False in case of netlink error

### DIFF
--- a/netconfig/aiproute.py
+++ b/netconfig/aiproute.py
@@ -82,11 +82,13 @@ class AIPRoute():
         except (IndexError, KeyError):
             return None
 
-    def _get_arp_cache(self, device_id: int, stale_timeout: int = 60) -> dict:
+    def _get_arp_cache(
+            self, device_id: int, stale_timeout: int = 60
+    ) -> dict | None:
         try:
             response = self.ipr.get_neighbours(ifindex=device_id)
         except NetlinkError:
-            return False
+            return None
 
         cache = {}
         for r in response:


### PR DESCRIPTION
**Fixing this ctest error**: `aiproute.py:89: error: Incompatible return value type (got "bool", expected "dict[Any, Any]")  [return-value]`

**From issue**: https://github.com/ccxtechnologies/builder/issues/4942

**Analysis**:

**Problem**: 
`_get_arp_cache` from `aiproute.py` function type hint is wrong, the return value is hinted as a `dict` but it returns `False` on a netlink error
  - we shouldn't return `False` from this function because the return value is treated as a `dict`, this will cause an error if we return `False` and use `.items()` for example, on the return value

**Fix**:
- Instead of returning `False` on a netlink error, returning `None` can indicate that something went wrong. Where the return value is used, it is checked first for if it's not `None` which will avoid applying dictionary methods to the value.
- Change the type hint to reflect the new return values: `dict | None`

see analysis:
- https://github.com/ccxtechnologies/builder/issues/4942#issuecomment-2789825885
- https://github.com/ccxtechnologies/builder/issues/4942#issuecomment-2797392537