### PR TITLE
fixing _add_device return type hint

### DIFF
--- a/netconfig/aiproute.py
+++ b/netconfig/aiproute.py
@@ -175,9 +175,7 @@ class AIPRoute():
         except (OSError, NetlinkError):
             raise RuntimeError(f"Failed to set {device_id} stp to {stp}")
 
-    def _add_device(
-            self, device_name: str, device_type: str, **kwargs
-    ) -> None:
+    def _add_device(self, device_name: str, device_type: str, **kwargs) -> int:
         try:
             self.ipr.link(
                     'add', ifname=device_name, kind=device_type, **kwargs


### PR DESCRIPTION
**Fixing this ctest error**:  `aiproute.py:206: error: No return value expected  [return-value]` 

**From issue**: https://github.com/ccxtechnologies/builder/issues/4942 
- See further analysis in comment: https://github.com/ccxtechnologies/builder/issues/4942#issuecomment-2790856854

#### Analysis:

**Problem**: 
- The `_add_device` function in aiproute.py is type hinted to return `None`, so mypy doesn’t expect a return value, but there is a return value:
	`return _id`
	
- From this [code segment](https://github.com/ccxtechnologies/netconfig/blob/85049a84186bed08690cee9f4fb199cd3d72c407/netconfig/aiproute.py#L197C9-L202C63), we know `_id` is not `None`. 

-  `_id` is the return value of [`_get_id`](https://github.com/ccxtechnologies/netconfig/blob/85049a84186bed08690cee9f4fb199cd3d72c407/netconfig/aiproute.py#L34), which returns an `int`.


**Conclusion**: a successful return from this function should return an int, otherwise raise a runtime error. `None` is not the correct type hint here, `int` is. 

- **Note** that the function was originally typed None when the function did not return anything, which would have been correct according to mypy, later, an explicit return was added but the type hint was not changed. See here: https://github.com/ccxtechnologies/netconfig/commit/2fe66ee550b64e849f4a7d1a1452dd5a690f4b13

**Fix**: change the type hint from `None` to `int`


