### PR TITLE
changing setblocking argument to False instead of 0

### DIFF
--- a/netconfig/arpreq.py
+++ b/netconfig/arpreq.py
@@ -21,7 +21,7 @@ async def arpreq(
     with socket.socket(
             socket.AF_PACKET, socket.SOCK_RAW, socket.SOCK_RAW
     ) as _socket:
-        _socket.setblocking(0)
+        _socket.setblocking(False)
         _socket.bind((if_name, socket.SOCK_RAW))
 
         # I would like to use something like asyncio.open_connection but


### PR DESCRIPTION
**Fixing this ctest error**: 
`arpreq.py:24: error: Argument 1 to "setblocking" of "socket" has incompatible type "int"; expected "bool"  [arg-type]`

**From issue**: https://github.com/ccxtechnologies/builder/issues/4942

**Analysis**: 

**Problem**: The `setblocking` function from Python's `socket` module expects a `bool` argument as described in the [typeshed type hints](https://github.com/python/typeshed/blob/f65bdc1acde54fda93c802459280da74518d2eef/stdlib/asyncio/trsock.pyi#L42), as well as the [documentation](https://docs.python.org/3/library/socket.html#socket.socket.setblocking):
> socket.setblocking(flag)
Set blocking or non-blocking mode of the socket: if flag is false, the socket is set to non-blocking, else to blocking mode.
This method is a shorthand for certain [settimeout()](https://docs.python.org/3/library/socket.html#socket.socket.settimeout) calls:
sock.setblocking(True) is equivalent to sock.settimeout(None)
sock.setblocking(False) is equivalent to sock.settimeout(0.0)

- [`mypy` uses typeshed type hints](https://mypy.readthedocs.io/en/stable/stubs.html#:~:text=Mypy%20uses%20stub%20files%20stored%20in%20the%20typeshed%20repository%20to%20determine%20the%20types%20of%20standard%20library%20and%20third%2Dparty%20library%20functions%2C%20classes%2C%20and%20other%20definitions.%20You%20can%20also%20create%20your%20own%20stubs%20that%20will%20be%20used%20to%20type%20check%20your%20code.), so passing an `int` type causes a typing error

**Conclusion**: The argument should be an explicit `bool` to match the type expectations of the function according to its official type hints and documentation.

**Fix**: Change `0` to `False` in the call to `setblocking`
