### PR TITLE
ignoring attr-defined mypy for protected method

### DIFF
--- a/netconfig/arpreq.py
+++ b/netconfig/arpreq.py
@@ -32,7 +32,7 @@ async def arpreq(
         if type(loop) == asyncio.unix_events._UnixSelectorEventLoop:  # noqa pylint:disable=protected-access
             reader = asyncio.streams.StreamReader(loop=loop)
             protocol = asyncio.streams.StreamReaderProtocol(reader, loop=loop)
-            await loop._create_connection_transport(  # noqa pylint:disable=protected-access
+            await loop._create_connection_transport(  # type: ignore [attr-defined] # noqa pylint:disable=protected-access
                     _socket, lambda: protocol, None, ''
             )
 


### PR DESCRIPTION
**Fixing this ctest error**: 
`arpreq.py:35: error: "_UnixSelectorEventLoop" has no attribute "_create_connection_transport"  [attr-defined]`

**From issue**: https://github.com/ccxtechnologies/builder/issues/4942

**Analysis**: 

**Problem**: 
In `arpreq`, `loop` of type `_UnixSelectorEventLoop` is accessing a protected method `_create_connection_transport`:
Relevant line: https://github.com/ccxtechnologies/netconfig/blob/85049a84186bed08690cee9f4fb199cd3d72c407/netconfig/arpreq.py#L35

`mypy` is not able to resolve that `_create_connection_transport` is a method for `_UnixSelectorEventLoop` objects. Python doesn't strictly enforce restricting access to protected methods, but type checkers will raise errors or warnings. Specifically, `mypy` uses stub files to resolve type issues (see [here](https://mypy.readthedocs.io/en/stable/stubs.html)), `mypy` pulls in these stubs from typeshed, and they represent the public interface of classes and functions. 
-> confirmed that we don't have `_create_connection_transport` in our stubs which is the root cause of this issue 
(see analysis [here](https://github.com/ccxtechnologies/builder/issues/4942#issuecomment-2818417345) and [here](https://github.com/ccxtechnologies/builder/issues/4942#issuecomment-2828491300))

**Note**: Other places where protected methods are used and this error doesn't show up, for example in `netlink.py`, where we also use `_create_connection_transport`, those functions are not being checked by `mypy` [because they are not type annotated](https://mypy.readthedocs.io/en/stable/common_issues.html#no-errors-reported-for-obviously-wrong-code). (See analysis [here](https://github.com/ccxtechnologies/builder/issues/4942#issuecomment-2836567400))


**Conclusion**: Editing a third party stub file or adding a protected method to a public interface is not the best solution. But because the root cause of the `mypy` error is the type resolution and we need to use the protected method specifically, we should ignore the `mypy` error.

**Fix**: Ignore the `mypy` error with `# type: ignore [attr-defined]` 