### PR TITLE
making frame a bytes object instead of list of bytes to begin with

### DIFF
--- a/netconfig/arpreq.py
+++ b/netconfig/arpreq.py
@@ -36,21 +36,23 @@ async def arpreq(
                     _socket, lambda: protocol, None, ''
             )
 
-        frame = [
-                pack('!6B',
-                     *(0xFF, ) * 6),
-                _socket.getsockname()[4],
-                pack('!H', 0x0806),
-                pack('!HHBB', 0x0001, 0x0800, 0x0006, 0x0004),
-                pack('!H', 0x0001),
-                _socket.getsockname()[4],
-                pack('!4B', *src_ipaddr.words),
-                pack('!6B',
-                     *(0, ) * 6),
-                pack('!4B', *dst_ipaddr.words)
-        ]
+        frame = b''.join(
+                [
+                        pack('!6B',
+                             *(0xFF, ) * 6),
+                        _socket.getsockname()[4],
+                        pack('!H', 0x0806),
+                        pack('!HHBB', 0x0001, 0x0800, 0x0006, 0x0004),
+                        pack('!H', 0x0001),
+                        _socket.getsockname()[4],
+                        pack('!4B', *src_ipaddr.words),
+                        pack('!6B',
+                             *(0, ) * 6),
+                        pack('!4B', *dst_ipaddr.words)
+                ]
+        )
 
-        _socket.send(b''.join(frame))
+        _socket.send(frame)
         send_time = time.time()
         recv_time = send_time
 

--- a/netconfig/arpreq.py
+++ b/netconfig/arpreq.py
@@ -36,21 +36,21 @@ async def arpreq(
                     _socket, lambda: protocol, None, ''
             )
 
-        frame = b''.join(
-                [
-                        pack('!6B',
-                             *(0xFF, ) * 6),
-                        _socket.getsockname()[4],
-                        pack('!H', 0x0806),
-                        pack('!HHBB', 0x0001, 0x0800, 0x0006, 0x0004),
-                        pack('!H', 0x0001),
-                        _socket.getsockname()[4],
-                        pack('!4B', *src_ipaddr.words),
-                        pack('!6B',
-                             *(0, ) * 6),
-                        pack('!4B', *dst_ipaddr.words)
-                ]
-        )
+        frame_list = [
+                pack('!6B',
+                     *(0xFF, ) * 6),
+                _socket.getsockname()[4],
+                pack('!H', 0x0806),
+                pack('!HHBB', 0x0001, 0x0800, 0x0006, 0x0004),
+                pack('!H', 0x0001),
+                _socket.getsockname()[4],
+                pack('!4B', *src_ipaddr.words),
+                pack('!6B',
+                     *(0, ) * 6),
+                pack('!4B', *dst_ipaddr.words)
+        ]
+
+        frame: bytes = b''.join(frame_list)
 
         _socket.send(frame)
         send_time = time.time()


### PR DESCRIPTION
**Fixing these ctest errors**: 
```
arpreq.py:62: error: Incompatible types in assignment (expression has type "bytes", variable has type "list[Any]")  [assignment]                                          
arpreq.py:64: error: Incompatible types in assignment (expression has type "bytes", variable has type "list[Any]")  [assignment]                                          
arpreq.py:79: error: Argument 2 to "unpack" has incompatible type "list[Any]"; expected "Buffer"  [arg-type]                                                              
arpreq.py:85: error: Argument 2 to "unpack" has incompatible type "list[Any]"; expected "Buffer"  [arg-type]
```

**From issue**: https://github.com/ccxtechnologies/builder/issues/5014

**Analysis**: 

**Problem**: In `arpreq`, we're initialising `frame` to be a list of `bytes` [here](https://github.com/ccxtechnologies/netconfig/blob/master/netconfig/arpreq.py#L39-L51). 
Every subsequent usage of `frame` however, is as a `bytes` object. This is incompatible with `mypy` because it will flag the type of `frame` as `list`, which is what is giving these four errors, because in each case, we're using a value derived from `frame` and `bytes` was actually expected. After initialising, it is turned into a `bytes` object through `join`: `b''.join(frame)`. 

**Conclusion**: Since we are awlays effectively using `frame` as a `bytes` object past its initialisation, it makes sense to simply initialise it as a bytes object to begin with.  

**Fix**: Move the `join` onto the same line as the initialisation of `frame`, so that it's consistently a `bytes` object. 

To see further analysis, see here: https://github.com/ccxtechnologies/builder/issues/5014#issuecomment-2873815674